### PR TITLE
Fixed GreaseMonkey support.

### DIFF
--- a/touch.user.js
+++ b/touch.user.js
@@ -8,10 +8,10 @@
 // this include string credits Twitch Plays Pokemon Chat Filter
 // @include    /^https?://(www|beta)\.twitch\.tv\/twitchplayspokemon.*$/
 
-// @updateURL  https://raw.githubusercontent.com/lostcoaster/twitch-touches-pokemon/master/touch.js
+// @updateURL  https://raw.githubusercontent.com/lostcoaster/twitch-touches-pokemon/master/touch.user.js
 // ==/UserScript==
 
-// for bookmarklet users : javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://raw.githubusercontent.com/lostcoaster/twitch-touches-pokemon/master/touch.js';})();
+// for bookmarklet users : javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://raw.githubusercontent.com/lostcoaster/twitch-touches-pokemon/master/touch.user.js';})();
 
 (function () {
 "use strict";


### PR DESCRIPTION
jQuery was undefined in the user script, as the global scope is different from the page's global scope. Access it through `unsafeWindow` when run as a user script, or the regular `window` otherwise.

Renamed the file to `touch.user.js`, as this is the convention for user scripts. Note that this _will_ break existing bookmarklets referring to the GitHub-hosted file.
