### PR TITLE
Update for new Twitch player

### DIFF
--- a/touch.user.js
+++ b/touch.user.js
@@ -155,9 +155,15 @@
         position: function (rx, ry) {
             try{
                 var base = $('#player,#videoPlayer');
-                if(!base.is('object')) // in tinytwitch #player is that object.
+                var bar_height = touch_pad.parameters.bar_height;
+                if (!base.is('object')) { // in tinytwitch #player is that object.
+                    if (base.find('.player-controls-bottom').length) {
+                        // HTML5 player controls in overlay on top of Flash player
+                        bar_height = 0;
+                    }
                     base = base.find('object'); // but in twitch player is just a div.
-                var height = base.height() - touch_pad.parameters.bar_height;
+                }
+                var height = base.height() - bar_height;
                 var base_offset = base.offset();
                 var real_height, real_width, left_margin, top_margin;
                 if (height / base.width() > touch_pad.parameters.ratio) {


### PR DESCRIPTION
Twitch recently rolled out an update to the video player. The new player uses HTML/CSS/JavaScript for the player UI, although the actual playback is still handled by Flash.

Most importantly, the player controls now appear in an overlay on top of the video instead of in a bar below it. This means that the adjustment for the bar height is no longer needed when positioning the touch overlay.

![newtwitchplayerui](https://cloud.githubusercontent.com/assets/649348/8823307/1fe0d952-306c-11e5-85c1-9f918480572f.PNG)

I'm not sure if this update has been rolled out to _all users_ immediately, or is being gradually rolled out to a part of the users. In the latter case, we'd need some extra detection to determine _if_ the bar height should be subtracted or not. I also haven't tested this with BetterTTV yet, not sure how that affects this.
